### PR TITLE
fix(modules): compact property area after resetting modified props (#103)

### DIFF
--- a/module/jni/modules.cpp
+++ b/module/jni/modules.cpp
@@ -219,4 +219,14 @@ void doMrProp()
         nullptr);
 
     LOGD("__system_property_foreach returned %d. resetCount=%d", ret, resetCount);
+
+    // After resetting modified properties, compact the property area to reclaim
+    // the space used by old entries. Without this, the property area leaks metadata
+    // about previously-modified props even after they're reset to their original
+    // values. See https://github.com/snake-4/Zygisk-Assistant/issues/103
+    if (resetCount > 0)
+    {
+        __system_property_compact();
+        LOGD("Compacted property area after resetting %d properties", resetCount);
+    }
 }


### PR DESCRIPTION
## What

After `doMrProp()` resets modified system properties back to their default values, the old entries still occupy space in the property area. This leaks metadata about previously-modified props even after they're reset.

## Why

Closes #103 (the maintainer's own TODO).

Without compaction, an app that iterates over the property area can still detect that *something* was modified, even if the value is now back to its original. This is the same metadata-leak problem Magisk's `resetprop -p` solves with `__system_property_compact()`.

## How

After the `__system_property_foreach()` reset loop completes, call `__system_property_compact()` to reclaim the space. Gated on `resetCount > 0` to skip the syscall when no resets happened.

```cpp
if (resetCount > 0)
{
    __system_property_compact();
    LOGD("Compacted property area after resetting %d properties", resetCount);
}
```

`__system_property_compact()` is exposed by the `aosp_system_properties` submodule this repo already vendors (topjohnwu/system_properties), so no new dependencies.

## Testing

Builds with the existing ndk-build setup. The compact syscall is a no-op if the area is already compact, so calling it when `resetCount == 0` would just be wasted work — hence the guard.

I don't have an Android device to runtime-test, but the change is minimal and mirrors what Magisk does in its `resetprop -p` path.